### PR TITLE
Исправлен тест на cocotb к модулю serial_to_parallel (8 блок курса)

### DIFF
--- a/src/08-cocotb/bus/bus_test.py
+++ b/src/08-cocotb/bus/bus_test.py
@@ -37,16 +37,16 @@ class HelperSerialParallel:  # <1>
                 self.res = [int(self.dut.s_data.value)] + self.res[
                     0 : self.OutWidth - 1
                 ]
-                self.counter += 1
-                if self.counter == self.OutWidth - 1:
+                if self.counter == self.OutWidth:
                     self.counter = 0
+                self.counter += 1
 
 
 @cocotb.test()
 async def bus_test(dut):
     NOfIterations = 1000
 
-    clock = Clock(dut.clk, 10, units="ns")  # <5>
+    clock = Clock(dut.clk, 10, unit="ns")  # <5>
     helper = HelperSerialParallel(dut)
     cocotb.start_soon(clock.start(start_high=False))  # <6>
 
@@ -62,8 +62,10 @@ async def bus_test(dut):
         await RisingEdge(dut.clk)
 
         cocotb.start_soon(helper.my_serial_to_parallel())
-        if helper.counter == helper.OutWidth - 1:
-            assert dut.m_valid, f"Incorrect m_valid = {dut.m_valid.value}"
+        if helper.counter == helper.OutWidth:
+            assert int(dut.m_valid.value), f"Incorrect m_valid = {dut.m_valid.value}"
             assert (
                 LogicArray(helper.res) == dut.m_data.value  # <8>
             ), f"m_data = {dut.m_data.value}, res = {LogicArray(helper.res)}"
+        else:
+            assert not int(dut.m_valid.value), f"Incorrect m_valid = {dut.m_valid.value}"


### PR DESCRIPTION
* Параметр `Clock()` был переименован из 'units' в 'unit', так как в версии cocotb 2.0.1 он называется 'unit'

* Раньше модель сначала увеличивала на 1 счётчик, и потом, если он становился равен `OutWidth - 1`, сразу сбрасывала его в 0. Поэтому условие в тесте `if helper.counter == helper.OutWidth - 1:` всегда было ложно и проверки не выполнялись.
Теперь, после исправления, модель сначала сбрасывает счётчик в 0, если он в предыдущий раз стал равен `OutWidth`, и только потом увеличивает счётчик на 1. Тогда, если заменить условие `if helper.counter == helper.OutWidth - 1:` на ` if helper.counter == helper.OutWidth:`, проверки будут выполняться, когда нужно.

* Проверка `assert dut.m_valid`  была изменена на `assert int(dut.m_valid.value)`, потому что иначе типы не могут корректно привестись.

* Добавлена проверка `assert not int(dut.m_valid.value)` при условии, что `counter != OutWidth`. Она позволит впредь избежать того, что тест зелёный, а ни одной проверки не было выполнено.